### PR TITLE
update create api request body

### DIFF
--- a/src/Forem.Api/ArticlesService.cs
+++ b/src/Forem.Api/ArticlesService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Forem.Api.Internal;
 using Forem.Api.Models;
 
 namespace Forem.Api

--- a/src/Forem.Api/ArticlesService.cs
+++ b/src/Forem.Api/ArticlesService.cs
@@ -11,24 +11,32 @@ namespace Forem.Api
 	{
 		public ArticlesService(Uri baseUri, HttpClient httpClient) : base(baseUri, httpClient) { }
 
-		public Task<UserArticle> CreateArticleAsync(string apiKey, string markdown)
+		public Task<UserArticle> CreateArticleAsync(string apiKey, ArticlePayload article)
 		{
 			return PostAsync<UserArticle>("/api/articles", new ArticleUpdate
 			{
-				Article = new ArticleUpdate.ArticlePayload
+				Article = new ArticlePayload
 				{
-					Markdown = markdown
+					Title = article.Title,
+					Published = article.Published,
+					Markdown = article.Markdown,
+					Tags = article.Tags,
+					Series = article.Series,
 				}
 			}, apiKey);
 		}
 
-		public Task<UserArticle> UpdateArticleAsync(string apiKey, int id, string markdown)
+		public Task<UserArticle> UpdateArticleAsync(string apiKey, int id, ArticlePayload article)
 		{
 			return PutAsync<UserArticle>($"/api/articles/{id}", new ArticleUpdate
 			{
-				Article = new ArticleUpdate.ArticlePayload
+				Article = new ArticlePayload
 				{
-					Markdown = markdown
+					Title = article.Title,
+					Published = article.Published,
+					Markdown = article.Markdown,
+					Tags = article.Tags,
+					Series = article.Series,
 				}
 			}, apiKey);
 		}

--- a/src/Forem.Api/IArticlesService.cs
+++ b/src/Forem.Api/IArticlesService.cs
@@ -1,5 +1,4 @@
-﻿using Forem.Api.Internal;
-using Forem.Api.Models;
+﻿using Forem.Api.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/Forem.Api/IArticlesService.cs
+++ b/src/Forem.Api/IArticlesService.cs
@@ -1,4 +1,5 @@
-﻿using Forem.Api.Models;
+﻿using Forem.Api.Internal;
+using Forem.Api.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -7,20 +8,20 @@ namespace Forem.Api
 	public interface IArticlesService
 	{
 		/// <summary>
-		/// Creates an article with the given markdown. Returns the new created article.
+		/// Creates an article. Returns the new created article.
 		/// </summary>
 		/// <param name="apiKey">The API key associated to the account that the article is created under.</param>
-		/// <param name="markdown">The article body, including any front matter.</param>
+		/// <param name="article">The article to create.</param>
 		/// <returns></returns>
-		Task<UserArticle> CreateArticleAsync(string apiKey, string markdown);
+		Task<UserArticle> CreateArticleAsync(string apiKey, ArticlePayload article);
 		/// <summary>
 		/// Updates the article with the specified ID. Returns the updated article.
 		/// </summary>
 		/// <param name="apiKey">The API key associated to the account that the article is created under.</param>
 		/// <param name="id">The existing article ID.</param>
-		/// <param name="markdown">The article body, including any front matter.</param>
+		/// <param name="article">The article to update.</param>
 		/// <returns></returns>
-		Task<UserArticle> UpdateArticleAsync(string apiKey, int id, string markdown);
+		Task<UserArticle> UpdateArticleAsync(string apiKey, int id, ArticlePayload article);
 		/// <summary>
 		/// Retrieves all published articles, ordered by descending popularity.
 		/// </summary>

--- a/src/Forem.Api/Internal/ArticleUpdate.cs
+++ b/src/Forem.Api/Internal/ArticleUpdate.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Forem.Api.Serialization;
 using Newtonsoft.Json;
 
 namespace Forem.Api.Internal
@@ -27,9 +28,11 @@ namespace Forem.Api.Internal
 		/// </summary>
 		[JsonProperty("body_markdown")]
 		public string Markdown { get; set; }
+
 		[JsonProperty("tags")]
-		public string[] Tags { get; set; }
-		
+		[JsonConverter(typeof(MultiTypeTagConverter))]
+		public IEnumerable<string> Tags { get; set; }
+
 		/// <summary>
 		/// Article series name. <br />
 		/// All articles belonging to the same series need to have the same name in this parameter.

--- a/src/Forem.Api/Internal/ArticleUpdate.cs
+++ b/src/Forem.Api/Internal/ArticleUpdate.cs
@@ -9,11 +9,32 @@ namespace Forem.Api.Internal
 	{
 		[JsonProperty("article")]
 		public ArticlePayload Article { get; set; }
+	}
+	public class ArticlePayload
+	{
+		[JsonProperty("title")]
+		public string Title { get; set; }
 
-		public class ArticlePayload
-		{
-			[JsonProperty("body_markdown")]
-			public string Markdown { get; set; }
-		}
+		/// <summary>
+		/// True to create a published article, false otherwise. Defaults to false
+		/// </summary>
+		[JsonProperty("published")]
+		public bool Published { get; set; }
+
+		/// <summary>
+		/// The body of the article. <br/>
+		/// It can contain an optional front matter
+		/// </summary>
+		[JsonProperty("body_markdown")]
+		public string Markdown { get; set; }
+		[JsonProperty("tags")]
+		public string[] Tags { get; set; }
+		
+		/// <summary>
+		/// Article series name. <br />
+		/// All articles belonging to the same series need to have the same name in this parameter.
+		/// </summary>
+		[JsonProperty("series")]
+		public string Series { get; set; }
 	}
 }

--- a/src/Forem.Api/Models/Article.cs
+++ b/src/Forem.Api/Models/Article.cs
@@ -6,8 +6,12 @@ using Newtonsoft.Json;
 
 namespace Forem.Api.Models
 {
+
 	public class Article
 	{
+
+		[JsonProperty("type_of")]
+		public string TypeOf { get; set; }
 		[JsonProperty("id")]
 		public int ArticleId { get; set; }
 		[JsonProperty("title")]
@@ -16,17 +20,19 @@ namespace Forem.Api.Models
 		public string Description { get; set; }
 		[JsonProperty("cover_image")]
 		public Uri CoverImage { get; set; }
+
+		[JsonProperty("readable_publish_date")]
+		public string ReadablePublishDate { get; set; }
+
 		[JsonProperty("social_image")]
 		public Uri SocialImage { get; set; }
-		[JsonProperty("created_at")]
-		public DateTime CreatedAt { get; set; }
-		[JsonProperty("published_at")]
-		public DateTime PublishedAt { get; set; }
-		[JsonProperty("edited_at")]
-		public DateTime? EditedAt { get; set; }
+		
 		[JsonProperty("tag_list")]
+		public string TagList { get; set; }
+
+		[JsonProperty("tags")]
 		[JsonConverter(typeof(MultiTypeTagConverter))]
-		public IEnumerable<string> TagList { get; set; }
+		public IEnumerable<string> Tags { get; set; }
 
 		[JsonProperty("slug")]
 		public string Slug { get; set; }
@@ -34,7 +40,7 @@ namespace Forem.Api.Models
 		public string Path { get; set; }
 		[JsonProperty("canonical_url")]
 		public Uri CanonicalUrl { get; set; }
-		[JsonProperty("article_url")]
+		[JsonProperty("url")]
 		public Uri ArticleUrl { get; set; }
 
 		[JsonProperty("comments_count")]
@@ -42,12 +48,38 @@ namespace Forem.Api.Models
 		[JsonProperty("positive_reactions_count")]
 		public int NumberOfReactions { get; set; }
 
-		[JsonProperty("body_html")]
-		public string BodyHtml { get; set; }
+		[JsonProperty("public_reactions_count")]
+		public int NumberOfPublicReactions { get; set; }
+
+		[JsonProperty("collection_id")]
+		public int? CollectionId { get; set; }
+
+		[JsonProperty("created_at")]
+		public DateTime CreatedAt { get; set; }
+		
+		[JsonProperty("edited_at")]
+		public DateTime? EditedAt { get; set; }
+
+		[JsonProperty("crossposted_at")]
+		public DateTime CrossPostedAt { get; set; }
+
+		[JsonProperty("published_at")]
+		public DateTime PublishedAt { get; set; }
+		[JsonProperty("last_comment_at")]
+		public DateTime LastCommentAt { get; set; }
+
+		[JsonProperty("published_timestamp")]
+		public DateTime PublishedTimestamp { get; set; }
+		
+		[JsonProperty("reading_time_minutes")]
+		public int ReadingTime { get; set; }
 
 		[JsonProperty("user")]
 		public User User { get; set; }
 		[JsonProperty("organization")]
 		public Organisation Organization { get; set; }
+
+		[JsonProperty("flare_tag")]
+		public FlareTag FlareTag { get; set; }
 	}
 }

--- a/src/Forem.Api/Models/Article.cs
+++ b/src/Forem.Api/Models/Article.cs
@@ -27,12 +27,12 @@ namespace Forem.Api.Models
 		[JsonProperty("social_image")]
 		public Uri SocialImage { get; set; }
 		
-		[JsonProperty("tag_list")]
-		public string TagList { get; set; }
-
 		[JsonProperty("tags")]
+		public string Tags { get; set; }
+
+		[JsonProperty("tag_list")]
 		[JsonConverter(typeof(MultiTypeTagConverter))]
-		public IEnumerable<string> Tags { get; set; }
+		public IEnumerable<string> TagList { get; set; }
 
 		[JsonProperty("slug")]
 		public string Slug { get; set; }

--- a/src/Forem.Api/Models/ArticleUpdate.cs
+++ b/src/Forem.Api/Models/ArticleUpdate.cs
@@ -4,7 +4,7 @@ using System.Text;
 using Forem.Api.Serialization;
 using Newtonsoft.Json;
 
-namespace Forem.Api.Internal
+namespace Forem.Api.Models
 {
 	internal class ArticleUpdate
 	{

--- a/src/Forem.Api/Models/UserArticle.cs
+++ b/src/Forem.Api/Models/UserArticle.cs
@@ -9,9 +9,7 @@ namespace Forem.Api.Models
 		[JsonProperty("published")]
 		public bool Published { get; set; }
 		[JsonProperty("body_markdown")]
-		public bool BodyMarkdown { get; set; }
+		public string BodyMarkdown { get; set; }
 
-		[JsonProperty("flare_tag")]
-		public FlareTag FlareTag { get; set; }
 	}
 }

--- a/tests/Forem.Api.Tests/ArticlesApiTests.cs
+++ b/tests/Forem.Api.Tests/ArticlesApiTests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Forem.Api.Internal;
 
 namespace Forem.Api.Tests
 {
@@ -14,14 +15,34 @@ namespace Forem.Api.Tests
 		public async Task CreateArticle_WithInvalidApiKeyThrowsException()
 		{
 			var articleService = new ArticlesService(BaseUri, HttpClient);
-			await articleService.CreateArticleAsync("NotARealApiKey", "Hello World");
+
+			var article = new ArticlePayload
+			{
+				Title = "Hello, World",
+				Published = false,
+				Markdown = "Hello DEV, this is my first post",
+				Tags = new string[] { "discuss", "help" },
+				Series = "Hello series"
+			};
+
+			await articleService.CreateArticleAsync("NotARealApiKey", article);
 		}
 
 		[TestMethod, ExpectedException(typeof(ApiException))]
 		public async Task UpdateArticle_WithInvalidApiKeyThrowsException()
 		{
 			var articleService = new ArticlesService(BaseUri, HttpClient);
-			await articleService.UpdateArticleAsync("NotARealApiKey", 5, "Hello World");
+
+			var article = new ArticlePayload
+			{
+				Title = "Hello, World",
+				Published = false,
+				Markdown = "Hello DEV, this is my first post",
+				Tags = new string[] { "discuss", "help" },
+				Series = "Hello series"
+			};
+
+			await articleService.UpdateArticleAsync("NotARealApiKey", 5, article);
 		}
 
 		[TestMethod, ExpectedException(typeof(ApiException))]

--- a/tests/Forem.Api.Tests/ArticlesApiTests.cs
+++ b/tests/Forem.Api.Tests/ArticlesApiTests.cs
@@ -1,10 +1,8 @@
 using Forem.Api.Models;
-using Forem.Api;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Forem.Api.Internal;
 
 namespace Forem.Api.Tests
 {
@@ -98,7 +96,7 @@ namespace Forem.Api.Tests
 			var articleService = new ArticlesService(BaseUri, HttpClient);
 			var articles = await articleService.GetArticlesByTagAsync("react");
 			Assert.IsNotNull(articles);
-			Assert.IsTrue(articles.All(a => a.TagList.Contains("react", StringComparison.OrdinalIgnoreCase)));
+			Assert.IsTrue(articles.All(a => a.Tags.Contains("react", StringComparison.OrdinalIgnoreCase)));
 		}
 
 		[TestMethod]

--- a/tests/Forem.Api.Tests/ArticlesApiTests.cs
+++ b/tests/Forem.Api.Tests/ArticlesApiTests.cs
@@ -98,7 +98,7 @@ namespace Forem.Api.Tests
 			var articleService = new ArticlesService(BaseUri, HttpClient);
 			var articles = await articleService.GetArticlesByTagAsync("react");
 			Assert.IsNotNull(articles);
-			Assert.IsTrue(articles.All(a => a.TagList.Contains("react", StringComparer.OrdinalIgnoreCase)));
+			Assert.IsTrue(articles.All(a => a.TagList.Contains("react", StringComparison.OrdinalIgnoreCase)));
 		}
 
 		[TestMethod]


### PR DESCRIPTION
- updated create and update article endpoints to have article payload instead of a markdown string
I am not sure why `ArticleUpdate` class is inside a different directory `/Internal` from other models.

- updated article and user article models too.